### PR TITLE
fix(streamhandler): auto-configure streamhandler

### DIFF
--- a/fleece/log.py
+++ b/fleece/log.py
@@ -1,6 +1,10 @@
 import logging
+import sys
 
 import structlog
+
+LOG_FORMAT = '%(message)s'
+DEFAULT_STREAM = sys.stdout
 
 
 class logme(object):
@@ -25,7 +29,27 @@ class logme(object):
         return wrapped
 
 
-def get_logger(level=logging.DEBUG, name=None):
+def _has_streamhandler(logger, level=None, fmt=LOG_FORMAT,
+                       stream=DEFAULT_STREAM):
+    """Check the named logger for an appropriate existing StreamHandler.
+
+    This only returns True if a StreamHandler that exaclty matches
+    our specification is found. If other StreamHandlers are seen,
+    we assume they were added for a different purpose.
+    """
+    for handler in logger.handlers:
+        if not isinstance(handler, logging.StreamHandler):
+            continue
+        if handler.stream is not stream:
+            continue
+        if handler.level != level:
+            continue
+        if not handler.formatter or handler.formatter._fmt != fmt:
+            continue
+        return True
+
+
+def get_logger(level=logging.DEBUG, name=None, stream=DEFAULT_STREAM):
     WrappedDictClass = structlog.threadlocal.wrap_dict(dict)
     structlog.configure(
         processors=[
@@ -43,5 +67,11 @@ def get_logger(level=logging.DEBUG, name=None):
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True)
     log = structlog.get_logger(name)
+    if not _has_streamhandler(logging.getLogger(name),
+                              level=level, stream=stream):
+        streamhandler = logging.StreamHandler(stream)
+        streamhandler.setLevel(level)
+        streamhandler.setFormatter(logging.Formatter(fmt=LOG_FORMAT))
+        log.addHandler(streamhandler)
     log.setLevel(level)
     return log

--- a/fleece/log.py
+++ b/fleece/log.py
@@ -20,10 +20,9 @@ class logme(object):
     def __call__(self, func):
 
         def wrapped(*args, **kwargs):
-            self.logger.log(self.level, "Entering %s" % func.__name__)
+            self.logger.log(self.level, "Entering %s", func.__name__)
             response = func(*args, **kwargs)
-            self.logger.log(self.level,
-                            "Exiting %s" % func.__name__,
+            self.logger.log(self.level, "Exiting %s", func.__name__,
                             response=response)
             return response
         return wrapped
@@ -50,7 +49,8 @@ def _has_streamhandler(logger, level=None, fmt=LOG_FORMAT,
 
 
 def get_logger(level=logging.DEBUG, name=None, stream=DEFAULT_STREAM):
-    WrappedDictClass = structlog.threadlocal.wrap_dict(dict)
+    """Configure and return a logger with structlog and stdlib."""
+    wrap_dict_class = structlog.threadlocal.wrap_dict(dict)
     structlog.configure(
         processors=[
             structlog.stdlib.filter_by_level,
@@ -62,7 +62,7 @@ def get_logger(level=logging.DEBUG, name=None, stream=DEFAULT_STREAM):
             structlog.processors.format_exc_info,
             structlog.processors.JSONRenderer(sort_keys=True)
         ],
-        context_class=WrappedDictClass,
+        context_class=wrap_dict_class,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True)


### PR DESCRIPTION
Configure the StreamHandler to DEFAULT_STREAM
upon calls to get_logger(). Inspects existing
streamhandlers in case get_logger() is called
multiple times (or by multiple modules) to avoid
duplicate log entries.