### PR TITLE
Catch missing token better

### DIFF
--- a/fleece/raxauth.py
+++ b/fleece/raxauth.py
@@ -8,7 +8,7 @@ def authenticate():
         """Return a decorated callable."""
         def wrapped(*args, **kwargs):
             """Validate token and return auth context."""
-            if 'token' not in kwargs:
+            if not kwargs.get('token'):
                 raise HTTPError(status=401)
             userinfo = validate(kwargs['token'])
             if 'userinfo' in kwargs:


### PR DESCRIPTION
Fixing issue where if `token` was `None` then `HTTPError` was not raised and empty token was passed all the way to `validate()` and authenticate would return a 403 error from identity service due to a malformed request.

Using `kwargs.get('token')` will evaluate to `None` if token is falsey and will raise a 401 as expected.