### PR TITLE
Default to 401 for invalid tokens

### DIFF
--- a/fleece/raxauth.py
+++ b/fleece/raxauth.py
@@ -29,5 +29,5 @@ def validate(token):
     resp = requests.get(auth_url, headers=headers)
 
     if not resp.status_code == 200:
-        raise HTTPError(status=resp.status_code)
+        raise HTTPError(status=401)
     return resp.json()


### PR DESCRIPTION
The method used for validating tokens will return a 404 if the token is invalid. This patch makes sure that identity failures return a 401.