### PR TITLE
attach response context to a namespaced key for the wrapped function

### DIFF
--- a/fleece/log.py
+++ b/fleece/log.py
@@ -23,8 +23,9 @@ class logme(object):
         def wrapped(*args, **kwargs):
             self.logger.log(self.level, "Entering %s", func.__name__)
             response = func(*args, **kwargs)
-            self.logger.log(self.level, "Exiting %s", func.__name__,
-                            response=response)
+            func_response_name = "{0}_response".format(func.__name__)
+            kwarg = {func_response_name: response}
+            self.logger.log(self.level, "Exiting %s", func.__name__, **kwarg)
             return response
 
         return wrapped


### PR DESCRIPTION
```python
from log import logme
from log import get_logger
log = get_logger()


@logme(logger=log)
def test_case():
    return "test"


test_case()
```

now generates output as follows

```
{"event": "Entering test_case", "level": "debug", "logger": "root", "timestamp": "2016-06-02T19:23:40.494953Z"}
{"event": "Exiting test_case", "level": "debug", "logger": "root", "test_case_response": "test", "timestamp": "2016-06-02T19:23:40.495856Z"}
```