### PR TITLE
Do not log raw responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ coverage/
 
 .python-version
 README.rst
+
+.vscode/

--- a/fleece/xray.py
+++ b/fleece/xray.py
@@ -375,7 +375,6 @@ def extract_aws_metadata(wrapped, instance, args, kwargs, return_value):
         'Extracting AWS metadata',
         args=args,
         kwargs=kwargs,
-        response=response,
     )
     if 'operation_name' in kwargs:
         operation_name = kwargs['operation_name']
@@ -445,7 +444,6 @@ def extract_http_metadata(wrapped, instance, args, kwargs, return_value):
         'Extracting HTTP metadata',
         args=args,
         kwargs=kwargs,
-        response=response,
     )
     if 'request' in kwargs:
         request = kwargs['request']


### PR DESCRIPTION
In the HTTP (requests) case, the string representation of the response is not really helpful, and in the AWS case the raw response might contain stuff that raises UnicodeDecodeErrors (in some edge cases, it contains binary data).