### PR TITLE
Add 'fleece run' command to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,56 @@ if __name__ == '__main__':
     app = get_connexion_app('myapi', 'swagger.yml')
     app.run(8080)
 ```
+
+## Fleece CLI
+
+Fleece offers a limited functionality CLI to help build Lambda packages and run commands in a shell environment with AWS credentials from a Rackspace Fanatical AWS Account. The CLI functionality is not installed by default but can be installed as an extras package. NOTE: Package building with Fleece requires Docker.
+
+### Installation
+
+```
+pip install fleece[cli]
+```
+
+### `fleece run`
+
+```
+usage: fleece run [-h] [--username USERNAME] [--apikey APIKEY]
+                  [--config CONFIG] [--account ACCOUNT]
+                  [--environment ENVIRONMENT] [--role ROLE]
+                  command
+
+Run command in environment with AWS credentials from Rackspace FAWS API
+
+positional arguments:
+  command               Command to execute
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --username USERNAME, -u USERNAME
+                        Rackspace username. Can also be set via RS_USERNAME
+                        environment variable
+  --apikey APIKEY, -k APIKEY
+                        Rackspace API key. Can also be set via RS_API_KEY
+                        environment variable
+  --config CONFIG, -c CONFIG
+                        Path to YAML config file with defined accounts and
+                        aliases. Default is ./environments.yml
+  --account ACCOUNT, -a ACCOUNT
+                        AWS account number. Cannot be used with
+                        `--environment`
+  --environment ENVIRONMENT, -e ENVIRONMENT
+                        Environment alias to AWS account defined in config
+                        file. Cannot be used with `--account`
+  --role ROLE, -r ROLE  Role name to assume after obtaining credentials from
+                        FAWS API
+```
+
+```
+# fleece run --username $username --apikey $apikey --account $account 'aws s3 ls'
+2017-10-02 12:03:18 bucket1
+2017-06-08 14:31:07 bucket2
+2017-08-10 17:28:47 bucket3
+2017-08-10 17:21:58 bucket4
+2017-08-15 20:33:02 bucket5
+```

--- a/fleece/cli/main.py
+++ b/fleece/cli/main.py
@@ -1,7 +1,7 @@
 import sys
 import pkg_resources
 
-commands = ['build']
+commands = ['build', 'run']
 
 
 def main():

--- a/fleece/cli/main.py
+++ b/fleece/cli/main.py
@@ -6,16 +6,20 @@ commands = ['build', 'run']
 
 def main():
     if sys.argv[1] in commands:
-        # if there is an extra with the name of this command, check that the
-        # dependencies are installed before executing the command
+        # Check that the CLI dependencies are installed before executing the
+        # command.
         deps = pkg_resources.get_distribution('fleece')._dep_map.get(
-            sys.argv[1], [])
+            'cli', [])
         for dep in deps:
             try:
-                __import__(dep.project_name)
+                # PyYAML really messes this up.
+                if dep.project_name == 'PyYAML':
+                    __import__('yaml')
+                else:
+                    __import__(dep.project_name)
             except ImportError:
                 print('Dependency "{}" is not installed. Did you run '
-                      '"pip install fleece[{}]"?'.format(dep, sys.argv[1]))
+                      '"pip install fleece[cli]"?'.format(dep))
                 sys.exit(1)
 
         # execute the command

--- a/fleece/cli/run/__init__.py
+++ b/fleece/cli/run/__init__.py
@@ -1,0 +1,1 @@
+from fleece.cli.run.run import main  # noqa

--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+import argparse
+import os
+import subprocess
+import sys
+
+import boto3
+import requests
+import yaml
+
+
+RS_AUTH_ERROR = 'Rackspace authentication failed:\nStatus: {}\nResponse: {}'
+ACCT_NOT_FOUND_ERROR = 'No AWS account for `{}` found in config'
+NO_USER_OR_APIKEY_ERROR = 'You must provide a Rackspace username and apikey'
+ENV_AND_ACCT_ERROR = 'Use only ONE of `--environment` or `--account`'
+NO_ACCT_OR_ENV_ERROR = 'You must provide either `--environment` or `--account`'
+ENV_AND_ROLE_ERROR = ('`--role` cannot be used with `--environment` '
+                      '- use `role: <rolename>` in the config file instead')
+FAWS_API_URL = ('https://accounts.api.manage.rackspace.com/v0/awsAccounts/{0}'
+                '/credentials')
+RS_IDENTITY_URL = 'https://identity.api.rackspacecloud.com/v2.0/tokens'
+FAWS_API_ERROR = ('Could not fetch AWS Account credentials.\nStatus: {}\n'
+                  'Reason: {}')
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(
+        prog='fleece run',
+        description=('Run command in environment with AWS credentials from '
+                     'Rackspace FAWS API')
+    )
+    parser.add_argument('--username', '-u', type=str,
+                        default=os.environ.get('RS_USERNAME'),
+                        help=('Rackspace username. Can also be set via '
+                              'RS_USERNAME environment variable'))
+    parser.add_argument('--apikey', '-k', type=str,
+                        default=os.environ.get('RS_API_KEY'),
+                        help=('Rackspace API key. Can also be set via '
+                              'RS_API_KEY environment variable'))
+    parser.add_argument('--config', '-c', type=str,
+                        default='./environments.yml',
+                        help=('Path to YAML config file with defined accounts '
+                              'and aliases. Default is ./environments.yml'))
+    parser.add_argument('--account', '-a', type=str,
+                        help=('AWS account number. Cannot be used with '
+                              '`--environment`'))
+    parser.add_argument('--environment', '-e', type=str,
+                        help=('Environment alias to AWS account defined in '
+                              'config file. Cannot be used with `--account`'))
+    parser.add_argument('--role', '-r', type=str,
+                        help=('Role name to assume after obtaining credentials'
+                              ' from FAWS API'))
+    parser.add_argument('command', type=str, help=('Command to execute'))
+    return parser.parse_args(args)
+
+
+def assume_role(credentials, account, role):
+    """Use FAWS provided credentials to assume defined role."""
+    sts = boto3.client(
+        'sts',
+        aws_access_key_id=credentials['accessKeyId'],
+        aws_secret_access_key=credentials['secretAccessKey'],
+        aws_session_token=credentials['sessionToken'],
+    )
+    resp = sts.assume_role(
+        RoleArn='arn:aws:sts::{}:role/{}'.format(account, role),
+        RoleSessionName='fleece_assumed_role'
+    )
+    return {
+        'accessKeyId': resp['Credentials']['AccessKeyId'],
+        'secretAccessKey': resp['Credentials']['SecretAccessKey'],
+        'sessionToken': resp['Credentials']['SessionToken'],
+    }
+
+
+def get_account(config, environment):
+    """Find environment name in config object and return AWS account."""
+    account = None
+    for env in config.get('environments', []):
+        if env.get('name') == environment:
+            account = env.get('account')
+            role = env.get('role')
+    if not account:
+        sys.exit(ACCT_NOT_FOUND_ERROR.format(environment))
+    return account, role
+
+
+def get_aws_creds(account, tenant, token):
+    """Get AWS account credentials to enable access to AWS.
+
+    Returns a time bound set of AWS credentials.
+    """
+    url = (FAWS_API_URL.format(account))
+    headers = {
+        'X-Auth-Token': token,
+        'X-Tenant-Id': tenant,
+    }
+    response = requests.post(url, headers=headers,
+                             json={'credential': {'duration': '3600'}})
+
+    if not response.ok:
+        sys.exit(FAWS_API_ERROR.format(response.status_code, response.text))
+    return response.json()['credential']
+
+
+def get_config(config_file):
+    """Get config file and parse YAML into dict."""
+    config_path = os.path.abspath(config_file)
+
+    try:
+        with open(config_path, 'r') as data:
+            config = yaml.safe_load(data)
+    except IOError as exc:
+        sys.exit(str(exc))
+
+    return config
+
+
+def get_rackspace_token(username, apikey):
+    """Get Rackspace Identity token.
+
+    Login to Rackspace with cloud account and api key from environment vars.
+    Returns dict of the token and tenant id.
+    """
+    auth_params = {
+        "auth": {
+            "RAX-KSKEY:apiKeyCredentials": {
+                "username": username,
+                "apiKey": apikey,
+            }
+        }
+    }
+    response = requests.post(RS_IDENTITY_URL, json=auth_params)
+    if not response.ok:
+        sys.exit(RS_AUTH_ERROR.format(response.status_code, response.text))
+
+    identity = response.json()
+    return (identity['access']['token']['id'],
+            identity['access']['token']['tenant']['id'])
+
+
+def validate_args(args):
+    """Validate command-line arguments."""
+    if not any([args.environment, args.account]):
+        sys.exit(NO_ACCT_OR_ENV_ERROR)
+    if args.environment and args.account:
+        sys.exit(ENV_AND_ACCT_ERROR)
+    if args.environment and args.role:
+        sys.exit(ENV_AND_ROLE_ERROR)
+    if not all([args.username, args.apikey]):
+        sys.exit(NO_USER_OR_APIKEY_ERROR)
+
+
+def run(args):
+    role = args.role
+
+    if args.environment:
+        config = get_config(args.config)
+        account, role = get_account(config, args.environment)
+    else:
+        account = args.account
+
+    token, tenant = get_rackspace_token(args.username, args.apikey)
+    faws_credentials = get_aws_creds(account, tenant, token)
+
+    if role:
+        aws_credentials = assume_role(faws_credentials, account, role)
+    else:
+        aws_credentials = faws_credentials
+
+    env = os.environ.copy()
+    env['AWS_ACCESS_KEY_ID'] = aws_credentials['accessKeyId']
+    env['AWS_SECRET_ACCESS_KEY'] = aws_credentials['secretAccessKey']
+    env['AWS_SESSION_TOKEN'] = aws_credentials['sessionToken']
+
+    process = subprocess.Popen(
+        args.command,
+        env=env,
+        shell=True,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+    )
+    for line in iter(process.stdout.readline, ''):
+        sys.stdout.write(line)
+
+
+def main(args):
+    parsed_args = parse_args(args)
+    validate_args(parsed_args)
+    run(parsed_args)

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,5 +3,6 @@
 coverage==4.0.3
 flake8==2.5.1
 mock==2.0.0
+moto==1.1.24
 nose==1.3.7
 pylint==1.5.4

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,9 @@ EXTRAS_REQUIRE = {
         'Flask==0.12.2',
         'Werkzeug==0.12.2',
     ],
-    'build': [
-        'docker==2.5.1'
+    'cli': [
+        'docker==2.5.1',
+        'PyYAML>=3.12',
     ],
     'wsgi': [
         'Werkzeug==0.12.2',

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,0 +1,219 @@
+import unittest
+
+from moto import mock_sts
+import six
+import yaml
+
+from fleece.cli.run import run
+from . import utils
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
+
+class TestCLIRun(unittest.TestCase):
+
+    def setUp(self):
+        self.aws_credentials = {
+            'credential': {
+                'accessKeyId': '123456',
+                'secretAccessKey': '987654',
+                'sessionToken': '456789',
+            }
+        }
+        self.account = '123456789012'
+        self.role = 'LambdaDeployRole'
+        self.environment = 'foo'
+        self.config = 'environments:\n  - name: {}\n    account: "{}"'.format(
+            self.environment, self.account)
+
+    def test_environment_or_account(self):
+        args = [
+            '--account',
+            self.account,
+            '--environment',
+            self.environment,
+            'wat'
+        ]
+
+        with self.assertRaises(SystemExit) as exc:
+            run.main(args)
+            self.assertIn(
+                run.ENV_AND_ACCT_ERROR,
+                str(exc.exception)
+            )
+
+    def test_no_account_or_environment(self):
+        args = ['wat']
+
+        with self.assertRaises(SystemExit) as exc:
+            run.main(args)
+            self.assertIn(
+                run.NO_ACCT_OR_ENV_ERROR,
+                str(exc.exception)
+            )
+
+    def test_environment_with_role(self):
+        args = [
+            '--environment',
+            'foo',
+            '--role',
+            self.role,
+            'wat'
+        ]
+
+        with self.assertRaises(SystemExit) as exc:
+            run.main(args)
+            self.assertIn(
+                run.ENV_AND_ROLE_ERROR,
+                str(exc.exception)
+            )
+
+    def test_no_username(self):
+        args = [
+            '--account',
+            self.account,
+            '--apikey',
+            'foo',
+            'wat'
+        ]
+
+        with self.assertRaises(SystemExit) as exc:
+            run.main(args)
+            self.assertIn(run.NO_USER_OR_APIKEY_ERROR, str(exc.exception))
+
+    def test_no_apikey(self):
+        args = [
+            '--account',
+            self.account,
+            '--username',
+            'foo',
+            'wat'
+        ]
+
+        with self.assertRaises(SystemExit) as exc:
+            run.main(args)
+            self.assertIn(run.NO_USER_OR_APIKEY_ERROR, str(exc.exception))
+
+    def test_good_rackspace_token(self):
+        response_mock = mock.MagicMock()
+        response_mock.ok = True
+        response_mock.json = lambda: utils.USER_DATA
+
+        with mock.patch('fleece.cli.run.run.requests.post',
+                        return_value=response_mock) as requests_mock:
+            token, tenant = run.get_rackspace_token('foo', 'bar')
+            requests_mock.assert_called_with(
+                'https://identity.api.rackspacecloud.com/v2.0/tokens',
+                json={
+                    'auth': {
+                        'RAX-KSKEY:apiKeyCredentials': {
+                            'username': 'foo',
+                            'apiKey': 'bar'
+                        }
+                    }
+                },
+            )
+        self.assertEqual(utils.TEST_TOKEN, token)
+        self.assertEqual(utils.USER_DATA['access']['token']['tenant']['id'],
+                         tenant)
+
+    def test_bad_rackspace_token(self):
+        response_mock = mock.MagicMock()
+        response_mock.ok = False
+        response_mock.status_code = 401
+        response_mock.text = 'Narp'
+        with mock.patch('fleece.cli.run.run.requests.post',
+                        return_value=response_mock):
+            with self.assertRaises(SystemExit) as exc:
+                run.get_rackspace_token('foo', 'bar')
+                self.assertIn(
+                    run.RS_AUTH_ERROR.format(response_mock.status_code,
+                                             response_mock.text),
+                    str(exc.exception),
+                )
+
+    def test_get_aws_creds(self):
+        response_mock = mock.MagicMock()
+        response_mock.ok = True
+        response_mock.json = mock.MagicMock(return_value=self.aws_credentials)
+        with mock.patch('fleece.cli.run.run.requests.post',
+                        return_value=response_mock) as requests_mock:
+            creds = run.get_aws_creds(self.account, '123456', 'foo')
+            requests_mock.assert_called_with(
+                run.FAWS_API_URL.format(self.account),
+                headers={
+                    'X-Auth-Token': 'foo',
+                    'X-Tenant-Id': '123456',
+                },
+                json={
+                    'credential': {
+                        'duration': '3600'
+                    }
+                },
+            )
+
+        self.assertDictEqual(self.aws_credentials['credential'], creds)
+
+    def test_get_aws_creds_fail(self):
+        response_mock = mock.MagicMock()
+        response_mock.ok = False
+        response_mock.status_code = 404
+        response_mock.test = 'Narp'
+        with mock.patch('fleece.cli.run.run.requests.post',
+                        return_value=response_mock):
+            with self.assertRaises(SystemExit) as exc:
+                run.get_aws_creds(self.account, '123456', 'foo')
+                self.assertIn(
+                    run.FAWS_API_ERROR.format(response_mock.status_code,
+                                              response_mock.text),
+                    str(exc.exception),
+                )
+
+    def test_assume_role(self):
+        with mock_sts():
+            creds = run.assume_role(self.aws_credentials['credential'],
+                                    self.account, self.role)
+
+            # There is currently a bug in moto that causes it to simply
+            # return the passed-in RoleArn instead of an actual assumed-role
+            # ARN. Disabling these until fixed in moto.
+            #
+            # expected_arn = 'arn:aws:sts::{}:assumed-role/{}/{}'.format(
+            #     self.account,
+            #     self.role,
+            #     'fleece_assumed_role',
+            # )
+            # self.assertEqual(
+            #     creds['AssumedRoleUser']['Arn'],
+            #     expected_arn,
+            # )
+
+            expected_keys = ['secretAccessKey', 'sessionToken', 'accessKeyId']
+            [self.assertIn(key, creds) for key in expected_keys]
+
+    def test_get_config(self):
+        mock_open = mock.mock_open(read_data=self.config)
+        with mock.patch('fleece.cli.run.run.open', mock_open, create=True):
+            config = run.get_config('./wat')
+
+        self.assertDictEqual(yaml.load(self.config), config)
+
+    def test_bad_config_file_path(self):
+        with self.assertRaises(SystemExit) as exc:
+            run.get_config('./nope')
+        self.assertIn('No such file or directory', str(exc.exception))
+
+    def test_get_account(self):
+        config = yaml.load(self.config)
+        account, role = run.get_account(config, self.environment)
+        self.assertEqual(account, self.account)
+        self.assertIsNone(role)
+
+    def test_environment_not_found(self):
+        with self.assertRaises(SystemExit) as exc:
+            run.get_account({}, self.environment)
+        self.assertIn(run.ACCT_NOT_FOUND_ERROR.format(self.environment),
+                      str(exc.exception))

--- a/tests/test_raxauth.py
+++ b/tests/test_raxauth.py
@@ -3,34 +3,12 @@ import unittest
 
 from fleece.httperror import HTTPError
 from fleece.raxauth import authenticate
-
-# This isn't a real token - go away.
-TEST_TOKEN = ('gAAAAABWq9MR30nr8Zx_-bgyAzBnWgFxnsxbup_cN01G7aoM66c7wEwz4r'
-              'QtTmniRVOhkVaF9a0Rt11IPMEqZ0mFk3bS7a4v4gAvmNa0-zE27UkuG58S'
-              'bRqe8zpyzRzyVEZsjR4fnza5')
-
-USER_DATA = {
-    'access': {
-        'token': {
-            'RAX-AUTH:authenticatedBy': ['PASSWORD'],
-            'expires': '2016-02-06T20:00:10.694Z',
-            'id': TEST_TOKEN,
-            'tenant': {
-                'id': '123456',
-                'name': '123456',
-            }
-        },
-        'user': {
-            'name': 'mytenantname',
-            'roles': [],
-        }
-    }
-}
+from . import utils
 
 
 def mock_validation(token):
-    if token == TEST_TOKEN:
-        return USER_DATA
+    if token == utils.TEST_TOKEN:
+        return utils.USER_DATA
     else:
         raise HTTPError(status=401)
 
@@ -44,7 +22,7 @@ class TestRaxAuth(unittest.TestCase):
 
     @mock.patch('fleece.raxauth.validate', side_effect=mock_validation)
     def test_raxauth(self, validation_function):
-        result = authentication_test(token=TEST_TOKEN, userinfo=None)
+        result = authentication_test(token=utils.TEST_TOKEN, userinfo=None)
         self.assertEqual(result, 'AUTHENTICATED')
 
     @mock.patch('fleece.raxauth.validate', side_effect=mock_validation)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,22 @@
+# This isn't a real token - go away.
+TEST_TOKEN = ('gAAAAABWq9MR30nr8Zx_-bgyAzBnWgFxnsxbup_cN01G7aoM66c7wEwz4r'
+              'QtTmniRVOhkVaF9a0Rt11IPMEqZ0mFk3bS7a4v4gAvmNa0-zE27UkuG58S'
+              'bRqe8zpyzRzyVEZsjR4fnza5')
+
+USER_DATA = {
+    'access': {
+        'token': {
+            'RAX-AUTH:authenticatedBy': ['PASSWORD'],
+            'expires': '2016-02-06T20:00:10.694Z',
+            'id': TEST_TOKEN,
+            'tenant': {
+                'id': '123456',
+                'name': '123456',
+            }
+        },
+        'user': {
+            'name': 'mytenantname',
+            'roles': [],
+        }
+    }
+}


### PR DESCRIPTION
Allows for running commands in an environment with STS credentials injected via FAWS API.

```
usage: fleece run [-h] [--username USERNAME] [--apikey APIKEY]
                  [--config CONFIG] [--account ACCOUNT]
                  [--environment ENVIRONMENT] [--role ROLE]
                  command

Run command in environment with AWS credentials from Rackspace FAWS API

positional arguments:
  command               Command to execute

optional arguments:
  -h, --help            show this help message and exit
  --username USERNAME, -u USERNAME
                        Rackspace username. Can also be set via RS_USERNAME
                        environment variable
  --apikey APIKEY, -k APIKEY
                        Rackspace API key. Can also be set via RS_API_KEY
                        environment variable
  --config CONFIG, -c CONFIG
                        Path to YAML config file with defined accounts and
                        aliases. Default is ./environments.yml
  --account ACCOUNT, -a ACCOUNT
                        AWS account number. Cannot be used with
                        `--environment`
  --environment ENVIRONMENT, -e ENVIRONMENT
                        Environment alias to AWS account defined in config
                        file. Cannot be used with `--account`
  --role ROLE, -r ROLE  Role name to assume after obtaining credentials from
                        FAWS API
```

```
# fleece run --username $username --apikey $apikey --account $account 'aws s3 ls'
2017-10-02 12:03:18 bucket1
2017-06-08 14:31:07 bucket2
2017-08-10 17:28:47 bucket3
2017-08-10 17:21:58 bucket4
2017-08-15 20:33:02 bucket5
```
```
# cat environments.yml
environments:
  - name: development
    account: '123456789012'
  - name: staging
    account: '123456789012'
  - name: testing
    account: '123456789012'
  - name: production
    account: '123456789012'
    role: LambdaDeployRole

# fleece run --username $username --apikey $apikey --environment testing 'aws s3 ls'
2017-10-02 12:03:18 bucket1
2017-06-08 14:31:07 bucket2
2017-08-10 17:28:47 bucket3
2017-08-10 17:21:58 bucket4
2017-08-15 20:33:02 bucket5
```