### PR TITLE
Fix Lambda JSON serialization issue with python3.6

### DIFF
--- a/fleece/handlers/wsgi.py
+++ b/fleece/handlers/wsgi.py
@@ -39,7 +39,7 @@ def wsgi_handler(event, context, app, logger):
     resp = list(app(environ, start_response))
     proxy = {'statusCode': int(wsgi_status[0].split()[0]),
              'headers': {h[0]: h[1] for h in wsgi_headers[0]},
-             'body': b''.join(resp)}
+             'body': b''.join(resp).decode('utf-8')}
 
     logger.info("Returning {}".format(proxy['statusCode']),
                 http_status=proxy['statusCode'])


### PR DESCRIPTION
Returning `bytes` objects from a Lambda in python3.6 causes the following error:

```
An error occurred during JSON serialization of response: b'0.0.0' is not JSON serializable
Traceback (most recent call last):
File "/var/lang/lib/python3.6/json/__init__.py", line 238, in dumps
**kw).encode(obj)
File "/var/lang/lib/python3.6/json/encoder.py", line 199, in encode
chunks = self.iterencode(o, _one_shot=True)
File "/var/lang/lib/python3.6/json/encoder.py", line 257, in iterencode
return _iterencode(o, 0)
File "/var/runtime/awslambda/bootstrap.py", line 110, in decimal_serializer
raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'0.0.0' is not JSON serializable
```

This is caused by the this section of the wsgi handler:

```
    proxy = {'statusCode': int(wsgi_status[0].split()[0]),
             'headers': {h[0]: h[1] for h in wsgi_headers[0]},
             'body': b''.join(resp)}
    return proxy
```

Since the `resp` object is a list of `bytes` objects, we still have to join on `b''`, but then we can simply decode it to `utf-8`.