### PR TITLE
Integrate the connexion glue with AWS proxy type API-G integrations

### DIFF
--- a/fleece/cli/main.py
+++ b/fleece/cli/main.py
@@ -4,7 +4,16 @@ import pkg_resources
 commands = ['build', 'run']
 
 
+def print_help():
+    print('Available sub-commands: {}.'.format(', '.join(commands)))
+    print('Use "fleece <sub-command> --help" for usage.')
+
+
 def main():
+    if len(sys.argv) == 1:
+        print_help()
+        sys.exit(0)
+
     if sys.argv[1] in commands:
         # Check that the CLI dependencies are installed before executing the
         # command.
@@ -30,5 +39,4 @@ def main():
         if sys.argv[1] not in ['--help', '-h']:
             print('"{}" is not an available fleece sub-command.'.format(
                 sys.argv[1]))
-        print('Available sub-commands: {}.'.format(', '.join(commands)))
-        print('Use "fleece <sub-command> --help" for usage.')
+        print_help()

--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -179,6 +179,7 @@ def run(args):
         shell=True,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
+        encoding='utf-8',
     )
     for line in iter(process.stdout.readline, ''):
         sys.stdout.write(line)

--- a/fleece/handlers/wsgi.py
+++ b/fleece/handlers/wsgi.py
@@ -1,14 +1,8 @@
 from werkzeug.test import EnvironBuilder
 
 
-def wsgi_handler(event, context, app, logger):
-    """lambda handler function.
-    This function creates a WSGI environment from the proxy integration event,
-    runs the WSGI app with it and collects its response, then translates the
-    response back into the format expected by the API Gateway proxy
-    integration.
-    """
-
+def build_wsgi_environ_from_event(event):
+    """Create a WSGI environment from the proxy integration event."""
     params = event.get('queryStringParameters')
     environ = EnvironBuilder(method=event.get('httpMethod') or 'GET',
                              path=event.get('path') or '/',
@@ -25,6 +19,17 @@ def wsgi_handler(event, context, app, logger):
         environ['SCRIPT_NAME'] = ''
     environ['wsgi.url_scheme'] = 'https'
     environ['lambda.event'] = event
+    return environ
+
+
+def wsgi_handler(event, context, app, logger):
+    """lambda handler function.
+    This function runs the WSGI app with it and collects its response, then
+    translates the response back into the format expected by the API Gateway
+    proxy integration.
+    """
+
+    environ = build_wsgi_environ_from_event(event)
     wsgi_status = []
     wsgi_headers = []
 


### PR DESCRIPTION
This would help us eliminate the request/response template definitions from the Swagger file.