### PR TITLE
Use universal_newlines to force default encoding

### DIFF
--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -179,7 +179,7 @@ def run(args):
         shell=True,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
-        encoding='utf-8',
+        universal_newlines=True,
     )
     for line in iter(process.stdout.readline, ''):
         sys.stdout.write(line)


### PR DESCRIPTION
The 'encoding' param for Popen was not added until
Python 3.6, so this breaks using the CLI on 2.7
which is the most common version for users. Forcing
'universal_newlines' makes Py3 return STDOUT and STDERR
as stings like Py2.7, so this seems like the least
hacky work-around.