### PR TITLE
Make sure to capture and return the exit code from fleece run

### DIFF
--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -184,6 +184,9 @@ def run(args):
     for line in iter(process.stdout.readline, ''):
         sys.stdout.write(line)
 
+    return_code = process.wait()
+    sys.exit(return_code)
+
 
 def main(args):
     parsed_args = parse_args(args)


### PR DESCRIPTION
`fleece run` should return the exit code of the command passed to it.