### PR TITLE
validate rax creds after reading config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ environments:
   - name: staging
     account: '123456789012'
     rs_username_var: MY_RS_USERNAME
-    rs_api_key_var: MY_RS_APIKEY
+    rs_apikey_var: MY_RS_APIKEY
   - name: testing
     account: '123456789012'
   - name: production

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ environments:
   - name: staging
     account: '123456789012'
     rs_username_var: MY_RS_USERNAME
-    rs_apikey_var: MY_RS_APIKEY
+    rs_api_key_var: MY_RS_APIKEY
   - name: testing
     account: '123456789012'
   - name: production
@@ -401,7 +401,7 @@ Writes the configuration variables for the given environment to stdout. There ar
 The encrypted configuration consists on a list of encrypted buffers that need to be decrypted and appended. The result of this operation is the JSON plaintext configuration. The following output is the output of `--python`, which includes the decrypt and decode logic:
 
 ```python
-ENCRYPTED_CONFIG = ['... encrypted blob here ...']                                         
+ENCRYPTED_CONFIG = ['... encrypted blob here ...']
 import base64
 import boto3
 import json

--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -80,8 +80,8 @@ def get_account(config, environment):
             role = env.get('role')
             username = os.environ.get(env.get('rs_username_var')) \
                 if env.get('rs_username_var') else None
-            apikey = os.environ.get(env.get('rs_apikey_var')) \
-                if env.get('rs_apikey_var') else None
+            apikey = os.environ.get(env.get('rs_api_key_var')) \
+                if env.get('rs_api_key_var') else None
     if not account:
         sys.exit(ACCT_NOT_FOUND_ERROR.format(environment))
     return account, role, username, apikey
@@ -149,8 +149,6 @@ def validate_args(args):
         sys.exit(ENV_AND_ACCT_ERROR)
     if args.environment and args.role:
         sys.exit(ENV_AND_ROLE_ERROR)
-    if not all([args.username, args.apikey]):
-        sys.exit(NO_USER_OR_APIKEY_ERROR)
 
 
 def run(args):
@@ -158,12 +156,16 @@ def run(args):
 
     if args.environment:
         config = get_config(args.config)
-        account, role, username, apikey = get_account(config, args.environment)
+        account, role, cfg_username, cfg_apikey = get_account(
+            config, args.environment)
     else:
+        cfg_username, cfg_apikey = None, None
         account = args.account
 
-    username = args.username or username or os.environ.get('RS_USERNAME')
-    apikey = args.apikey or apikey or os.environ.get('RS_APIKEY')
+    username = args.username or cfg_username or os.environ.get('RS_USERNAME')
+    apikey = args.apikey or cfg_apikey or os.environ.get('RS_API_KEY')
+    if not all([username, apikey]):
+        sys.exit(NO_USER_OR_APIKEY_ERROR)
     token, tenant = get_rackspace_token(username, apikey)
     faws_credentials = get_aws_creds(account, tenant, token)
 

--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -80,8 +80,8 @@ def get_account(config, environment):
             role = env.get('role')
             username = os.environ.get(env.get('rs_username_var')) \
                 if env.get('rs_username_var') else None
-            apikey = os.environ.get(env.get('rs_api_key_var')) \
-                if env.get('rs_api_key_var') else None
+            apikey = os.environ.get(env.get('rs_apikey_var')) \
+                if env.get('rs_apikey_var') else None
     if not account:
         sys.exit(ACCT_NOT_FOUND_ERROR.format(environment))
     return account, role, username, apikey

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -224,7 +224,7 @@ class TestCLIRun(unittest.TestCase):
             '  - name: {}\n'
             '    account: "{}"\n'
             '    rs_username_var: MY_USERNAME\n'
-            '    rs_api_key_var: MY_APIKEY'.format(
+            '    rs_apikey_var: MY_APIKEY'.format(
                 self.environment, self.account))
         account, role, username, apikey = run.get_account(config,
                                                           self.environment)

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -224,7 +224,7 @@ class TestCLIRun(unittest.TestCase):
             '  - name: {}\n'
             '    account: "{}"\n'
             '    rs_username_var: MY_USERNAME\n'
-            '    rs_apikey_var: MY_APIKEY'.format(
+            '    rs_api_key_var: MY_APIKEY'.format(
                 self.environment, self.account))
         account, role, username, apikey = run.get_account(config,
                                                           self.environment)


### PR DESCRIPTION
Looks like the username and api key were required now as CLI arguments,
as some code that read them from the environment variables had been
moved. Additionally the environment variable RS_API_KEY was changed to
RS_APIKEY, so this PR changes it back. It also changes `rs_apikey_var` to
`rs_api_key_var` for consistency.

This also allows the user to not specify the argument or the environment
variables for the username and api key if they come from different
environment variables set in the config file.