### PR TITLE
Exit if a custom environment variable is missing

### DIFF
--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -12,6 +12,8 @@ import yaml
 RS_AUTH_ERROR = 'Rackspace authentication failed:\nStatus: {}\nResponse: {}'
 ACCT_NOT_FOUND_ERROR = 'No AWS account for `{}` found in config'
 NO_USER_OR_APIKEY_ERROR = 'You must provide a Rackspace username and apikey'
+NO_USER_ENV_VAR_ERROR = 'Username environment variable `{}`, not found.'
+NO_APIKEY_ENV_VAR_ERROR = 'Api key environment variable `{}` not found.'
 ENV_AND_ACCT_ERROR = 'Use only ONE of `--environment` or `--account`'
 NO_ACCT_OR_ENV_ERROR = 'You must provide either `--environment` or `--account`'
 ENV_AND_ROLE_ERROR = ('`--role` cannot be used with `--environment` '
@@ -71,17 +73,27 @@ def assume_role(credentials, account, role):
     }
 
 
-def get_account(config, environment):
+def get_account(config, environment, cli_username, cli_apikey):
     """Find environment name in config object and return AWS account."""
     account = None
     for env in config.get('environments', []):
         if env.get('name') == environment:
             account = env.get('account')
             role = env.get('role')
-            username = os.environ.get(env.get('rs_username_var')) \
-                if env.get('rs_username_var') else None
-            apikey = os.environ.get(env.get('rs_apikey_var')) \
-                if env.get('rs_apikey_var') else None
+            if 'rs_username_var' in env:
+                username = os.environ.get(env['rs_username_var'], cli_username)
+                if not username:
+                    sys.exit(NO_USER_ENV_VAR_ERROR.format(
+                             env['rs_username_var']))
+            else:
+                username = None
+            if 'rs_apikey_var' in env:
+                apikey = os.environ.get(env['rs_apikey_var'], cli_apikey)
+                if not apikey:
+                    sys.exit(NO_APIKEY_ENV_VAR_ERROR.format(
+                             env['rs_apikey_var']))
+            else:
+                apikey = None
     if not account:
         sys.exit(ACCT_NOT_FOUND_ERROR.format(environment))
     return account, role, username, apikey
@@ -157,7 +169,7 @@ def run(args):
     if args.environment:
         config = get_config(args.config)
         account, role, cfg_username, cfg_apikey = get_account(
-            config, args.environment)
+            config, args.environment, args.username, args.apikey)
     else:
         cfg_username, cfg_apikey = None, None
         account = args.account

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -14,6 +14,11 @@ else:
     from unittest import mock
 
 
+def clear_env_var(name):
+    if name in os.environ:
+        del os.environ[name]
+
+
 class TestCLIRun(unittest.TestCase):
 
     def setUp(self):
@@ -210,7 +215,9 @@ class TestCLIRun(unittest.TestCase):
     def test_get_account(self):
         config = yaml.load(self.config)
         account, role, username, apikey = run.get_account(config,
-                                                          self.environment)
+                                                          self.environment,
+                                                          None,
+                                                          None)
         self.assertEqual(account, self.account)
         self.assertIsNone(role)
         self.assertIsNone(username)
@@ -227,7 +234,9 @@ class TestCLIRun(unittest.TestCase):
             '    rs_apikey_var: MY_APIKEY'.format(
                 self.environment, self.account))
         account, role, username, apikey = run.get_account(config,
-                                                          self.environment)
+                                                          self.environment,
+                                                          None,
+                                                          None)
         del os.environ['MY_USERNAME']
         del os.environ['MY_APIKEY']
         self.assertEqual(account, self.account)
@@ -235,8 +244,73 @@ class TestCLIRun(unittest.TestCase):
         self.assertEqual(username, 'foo')
         self.assertEqual(apikey, 'bar')
 
+    def test_get_account_with_missing_user_name(self):
+        clear_env_var('MY_USERNAME')
+        os.environ['MY_APIKEY'] = 'bar'
+        config = yaml.load(
+            'environments:\n'
+            '  - name: {}\n'
+            '    account: "{}"\n'
+            '    rs_username_var: MY_USERNAME\n'
+            '    rs_apikey_var: MY_APIKEY'.format(
+                self.environment, self.account))
+        with self.assertRaises(SystemExit) as exc:
+            run.get_account(config, self.environment, None, None)
+
+        assert (run.NO_USER_ENV_VAR_ERROR.format('MY_USERNAME')
+                in str(exc.exception))
+
+    def test_get_account_with_cli_user_name(self):
+        clear_env_var('MY_USERNAME')
+        os.environ['MY_APIKEY'] = 'bar'
+        config = yaml.load(
+            'environments:\n'
+            '  - name: {}\n'
+            '    account: "{}"\n'
+            '    rs_username_var: MY_USERNAME\n'
+            '    rs_apikey_var: MY_APIKEY'.format(
+                self.environment, self.account))
+
+        _, _, username, apikey = run.get_account(
+            config, self.environment, 'smith', None)
+        self.assertEqual('smith', username)
+        self.assertEqual('bar', apikey)
+
+    def test_get_account_with_missing_apikey(self):
+        os.environ['MY_USERNAME'] = 'foo'
+        clear_env_var('MY_APIKEY')
+        config = yaml.load(
+            'environments:\n'
+            '  - name: {}\n'
+            '    account: "{}"\n'
+            '    rs_username_var: MY_USERNAME\n'
+            '    rs_apikey_var: MY_APIKEY'.format(
+                self.environment, self.account))
+        with self.assertRaises(SystemExit) as exc:
+            run.get_account(config, self.environment, None, None)
+
+        print(str(exc.exception))
+        assert (run.NO_APIKEY_ENV_VAR_ERROR.format('MY_APIKEY')
+                in str(exc.exception))
+
+    def test_get_account_with_cli_apikey(self):
+        os.environ['MY_USERNAME'] = 'foo'
+        clear_env_var('MY_APIKEY')
+        config = yaml.load(
+            'environments:\n'
+            '  - name: {}\n'
+            '    account: "{}"\n'
+            '    rs_username_var: MY_USERNAME\n'
+            '    rs_apikey_var: MY_APIKEY'.format(
+                self.environment, self.account))
+
+        _, _, username, apikey = run.get_account(
+            config, self.environment, None, 'api-key')
+        self.assertEqual('foo', username)
+        self.assertEqual('api-key', apikey)
+
     def test_environment_not_found(self):
         with self.assertRaises(SystemExit) as exc:
-            run.get_account({}, self.environment)
+            run.get_account({}, self.environment, None, None)
         self.assertIn(run.ACCT_NOT_FOUND_ERROR.format(self.environment),
                       str(exc.exception))

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -216,8 +216,8 @@ class TestCLIRun(unittest.TestCase):
         config = yaml.load(self.config)
         account, role, username, apikey = run.get_account(config,
                                                           self.environment,
-                                                          None,
-                                                          None)
+                                                          False,
+                                                          False)
         self.assertEqual(account, self.account)
         self.assertIsNone(role)
         self.assertIsNone(username)
@@ -235,8 +235,8 @@ class TestCLIRun(unittest.TestCase):
                 self.environment, self.account))
         account, role, username, apikey = run.get_account(config,
                                                           self.environment,
-                                                          None,
-                                                          None)
+                                                          False,
+                                                          False)
         del os.environ['MY_USERNAME']
         del os.environ['MY_APIKEY']
         self.assertEqual(account, self.account)
@@ -255,7 +255,7 @@ class TestCLIRun(unittest.TestCase):
             '    rs_apikey_var: MY_APIKEY'.format(
                 self.environment, self.account))
         with self.assertRaises(SystemExit) as exc:
-            run.get_account(config, self.environment, None, None)
+            run.get_account(config, self.environment, True, True)
 
         assert (run.NO_USER_ENV_VAR_ERROR.format('MY_USERNAME')
                 in str(exc.exception))
@@ -272,8 +272,8 @@ class TestCLIRun(unittest.TestCase):
                 self.environment, self.account))
 
         _, _, username, apikey = run.get_account(
-            config, self.environment, 'smith', None)
-        self.assertEqual('smith', username)
+            config, self.environment, False, True)
+        self.assertEqual(None, username)
         self.assertEqual('bar', apikey)
 
     def test_get_account_with_missing_apikey(self):
@@ -287,7 +287,7 @@ class TestCLIRun(unittest.TestCase):
             '    rs_apikey_var: MY_APIKEY'.format(
                 self.environment, self.account))
         with self.assertRaises(SystemExit) as exc:
-            run.get_account(config, self.environment, None, None)
+            run.get_account(config, self.environment, True, True)
 
         print(str(exc.exception))
         assert (run.NO_APIKEY_ENV_VAR_ERROR.format('MY_APIKEY')
@@ -305,9 +305,9 @@ class TestCLIRun(unittest.TestCase):
                 self.environment, self.account))
 
         _, _, username, apikey = run.get_account(
-            config, self.environment, None, 'api-key')
+            config, self.environment, True, False)
         self.assertEqual('foo', username)
-        self.assertEqual('api-key', apikey)
+        self.assertEqual(None, apikey)
 
     def test_environment_not_found(self):
         with self.assertRaises(SystemExit) as exc:


### PR DESCRIPTION
The current behavior is that if a custom environment variable is missing fleece falls back to using RS_USERNAME or RS_API_KEY. I think it would be preferable if it raised an error.

My main motivation is I'm writing a Circle CI job that is setting RS_USERNAME and RS_API_KEY for the general case, and I want to use these other environment variables for a few jobs. However when they aren't set, fleece uses RS_USERNAME and RS_API_KEY, which is hard to figure out at a glance.