### PR TITLE
Allow fleece build to copy in content from symlinks

### DIFF
--- a/fleece/cli/build/build.py
+++ b/fleece/cli/build/build.py
@@ -82,7 +82,7 @@ def retrieve_archive(container, dist_dir):
 def put_files(container, src_dir, path, single_file_name=None):
     stream = BytesIO()
 
-    with tarfile.open(fileobj=stream, mode='w') as tar:
+    with tarfile.open(fileobj=stream, mode='w', dereference=True) as tar:
         if single_file_name:
             arcname = single_file_name
         else:


### PR DESCRIPTION
This changes causes `fleece build` to store the contents of symlinks into
the distribution. It works by copying anything symlink'd into the src
volume of the docker container used to build lambda_function.zip.