### PR TITLE
exclude files from build

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ usage: fleece build [-h] [--python36] [--rebuild]
                     [--requirements REQUIREMENTS]
                     [--dependencies DEPENDENCIES] [--target TARGET]
                     [--source SOURCE]
+                    [--exclude [EXCLUDE [EXCLUDE ...]]]
                     service_dir
 
 Simple Lambda builder.
@@ -218,6 +219,8 @@ optional arguments:
   --source SOURCE, -s SOURCE
                         source directory to include in lambda_function.zip
                         (default: $service_dir/src)
+  --exclude [EXCLUDE [EXCLUDE ...]], -e [EXCLUDE [EXCLUDE ...]]
+                        glob pattern to exclude
 ```
 
 To build a lambda package from the service's top-level directory:

--- a/fleece/cli/build/build.py
+++ b/fleece/cli/build/build.py
@@ -106,6 +106,15 @@ def create_volume(name):
     api.volumes.create(name)
 
 
+def destroy_volume(name):
+    api = docker.from_env(version='auto')
+    try:
+        volume = api.volumes.get(name)
+    except errors.NotFound:
+        return
+    volume.remove()
+
+
 def create_volume_container(image='alpine:3.4', command='/bin/true', **kwargs):
     api = docker.from_env(version='auto')
     api.images.pull(image)
@@ -307,6 +316,9 @@ def _build(service_name, python_version, src_dir, requirements_path,
         # Clean up generated containers
         clean_up_container(container)
         clean_up_container(src)
+        destroy_volume(dist_name)
+        destroy_volume(req_name)
+        destroy_volume(src_name)
 
         print('Build completed successfully.')
     sys.exit(exit_code)

--- a/fleece/cli/build/build.py
+++ b/fleece/cli/build/build.py
@@ -43,6 +43,8 @@ def parse_args(args):
                         help=('source directory to include in '
                               'lambda_function.zip (default: '
                               '$service_dir/src)'))
+    parser.add_argument('--exclude', '-e', type=str, nargs='+',
+                        help='glob pattern to exclude')
     parser.add_argument('service_dir', type=str,
                         help=('directory where the service is located '
                               '(default: $pwd)'))
@@ -179,6 +181,7 @@ def build(args):
                dependencies=dependencies,
                requirements_path=requirements_path,
                rebuild=args.rebuild,
+               exclude=args.exclude,
                dist_dir=dist_dir)
     else:
         print(pipfile)
@@ -192,6 +195,7 @@ def build(args):
                            dependencies=dependencies,
                            pipfile=pipfile,
                            rebuild=args.rebuild,
+                           exclude=args.exclude,
                            dist_dir=dist_dir)
 
         # If pipfile was specified, we need to write the requirements out
@@ -199,7 +203,7 @@ def build(args):
 
 
 def _build_with_pipenv(service_name, python_version, src_dir, pipfile,
-                       dependencies, rebuild, dist_dir):
+                       dependencies, rebuild, exclude, dist_dir):
     requirements_path = None
     tmpdir = tempfile.mkdtemp()
 
@@ -221,6 +225,7 @@ def _build_with_pipenv(service_name, python_version, src_dir, pipfile,
                requirements_path=requirements_path,
                dependencies=dependencies,
                rebuild=rebuild,
+               exclude=exclude,
                dist_dir=dist_dir)
     finally:
         if requirements_path:
@@ -232,7 +237,7 @@ def _build_with_pipenv(service_name, python_version, src_dir, pipfile,
 
 
 def _build(service_name, python_version, src_dir, requirements_path,
-           dependencies, rebuild, dist_dir):
+           dependencies, rebuild, exclude, dist_dir):
     print('Building {} with {}...'.format(service_name, python_version))
 
     try:
@@ -284,7 +289,9 @@ def _build(service_name, python_version, src_dir, requirements_path,
         environment={'DEPENDENCIES_SHA': dependencies_sha1,
                      'VERSION_HASH': get_version_hash(),
                      'BUILD_TIME': datetime.utcnow().isoformat(),
-                     'REBUILD_DEPENDENCIES': '1' if rebuild else '0'},
+                     'REBUILD_DEPENDENCIES': '1' if rebuild else '0',
+                     'EXCLUDE_PATTERNS': ' '.join(
+                         ['"{}"'.format(e) for e in exclude or []])},
         volumes_from=[src.id, build_cache.id],
         detach=True)
     for line in container.logs(stream=True, follow=True):

--- a/fleece/cli/build/docker_build_lambda.sh
+++ b/fleece/cli/build/docker_build_lambda.sh
@@ -12,7 +12,10 @@ fi
 cd /src
 rm -f /dist/lambda_function.zip
 cp /build_cache/${DEPENDENCIES_SHA}.zip /dist/lambda_function.zip
-zip -r /dist/lambda_function.zip .
+if [[ "$EXCLUDE_PATTERNS" != "" ]]; then
+    EXCLUDE="-x $EXCLUDE_PATTERNS"
+fi
+eval zip -r /dist/lambda_function.zip $EXCLUDE -- .
 cd /tmp
 echo "{\"VERSION_HASH\": \"${VERSION_HASH}\", \"BUILD_TIME\": \"${BUILD_TIME}\"}" > config.json
 zip -r /dist/lambda_function.zip config.json

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -95,6 +95,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             requirements_path=self.rel_path('src/requirements.txt'),
             dependencies=[''],
             rebuild=False,
+            exclude=None,
             dist_dir=self.rel_path('dist'),
         )
 
@@ -125,6 +126,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             requirements_path=self.rel_path('src/requirements.txt'),
             dependencies=[''],
             rebuild=False,
+            exclude=None,
             dist_dir=self.rel_path('dist'),
         )
 
@@ -144,7 +146,8 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
         self.make_file('src/requirements.txt', '')
 
         args = build.parse_args([
-            self.tmpdir, '--target', self.rel_path('crazy-dist')
+            self.tmpdir, '--target', self.rel_path('crazy-dist'), '--exclude',
+            'foo', 'bar'
         ])
         build.build(args)
 
@@ -157,6 +160,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             requirements_path=self.rel_path('src/requirements.txt'),
             dependencies=[''],
             rebuild=False,
+            exclude=['foo', 'bar'],
             dist_dir=self.rel_path('crazy-dist'),
         )
 
@@ -183,6 +187,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             requirements_path=self.rel_path('wacky-requirements.txt'),
             dependencies=[''],
             rebuild=False,
+            exclude=None,
             dist_dir=self.rel_path('dist'),
         )
 
@@ -244,6 +249,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             pipfile=self.rel_path('wacky-pipfile'),
             dependencies=[''],
             rebuild=False,
+            exclude=None,
             dist_dir=self.rel_path('dist'),
         )
 
@@ -282,6 +288,7 @@ class TestBuildWithPipenv(unittest.TestCase):
             'src_dir': 'src_dir',
             'dependencies': ['deps'],
             'rebuild': True,
+            'exclude': None,
             'dist_dir': 'dist_dir'
         }
 


### PR DESCRIPTION
Fixes #73 
Fixes #74 

This change adds a `--exclude` optional argument to `fleece build`, and also removes temporary docker volumes used during the build (except the one used for the build cache).

Example for `--exclude`:

    fleece build --requirements src/requirements.txt -s src -e foo.txt \*.pyc -- .

With this command, the zip package in directory `src` will be built, but files `foo.txt` and `*.pyc` will be excluded. Note that the `*` in the glob pattern is escaped with a `\` to prevent expansion as part of the build command (expansion will be carried out when the zip file is built).