### PR TITLE
pass pip configuration to build container

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ $ fleece build .
 
 The assumptions made with the above command are that the source code of the service is in `./src`, the requirements file is in `./src/requirements.txt` and the output zip file will be written to `./dist`. These defaults can be changed with the `--source`, `--requirements` and `--target` options respectively.
 
-The build process will run in a Docker container based on the Amazon Linux image. If there are any additional dependencies that need to be installed on the container prior to installing the Python requirements, those can be given with the `--dependencies` option.
+The build process will run in a Docker container based on the Amazon Linux image. If there are any additional dependencies that need to be installed on the container prior to installing the Python requirements, those can be given with the `--dependencies` option. Any environment variables recognized by `pip`, such as `PIP_INDEX_URL`, are passed on to the container.
 
 ### `fleece run`
 


### PR DESCRIPTION
This simple change adds configuration variables for `pip` found in the environment of the build process to the environment of the build container. This enables access to private package repositories, for example, through the `PIP_INDEX_URL` configuration variable.