### PR TITLE
Pin amazonlinux to Amazon Linux AMI not AL2

### DIFF
--- a/fleece/cli/build/Dockerfile
+++ b/fleece/cli/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:1
 
 ARG python_version=python27
 ARG deps


### PR DESCRIPTION
The latest tag on the `amazonlinux` docker image now points to AL2 instead of the previous Amazon Linux AMI version. AL2 features a lot of changes, and one of them is that the python36 package is now python3 which causes `fleece build` to fail. This locks the build container to AL1 for the time being until we can fully evaluate switching to AL2.