### PR TITLE
Use `stages` property from config in run

### DIFF
--- a/fleece/cli/config/config.py
+++ b/fleece/cli/config/config.py
@@ -60,7 +60,10 @@ STATE = {
 def _get_stage_data(stage, data=None):
     if not data:
         data = STATE['stages']
-    return run._get_stage_data(stage, data)
+    data = run.get_stage_data(stage, data)
+    if data is None:
+        raise ValueError('No match for stage "{}"'.format(stage))
+    return data
 
 
 def _get_kms_key(stage):

--- a/fleece/cli/config/config.py
+++ b/fleece/cli/config/config.py
@@ -3,7 +3,6 @@ import argparse
 import base64
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -61,13 +60,7 @@ STATE = {
 def _get_stage_data(stage, data=None):
     if not data:
         data = STATE['stages']
-    if stage in data:
-        return data[stage]
-    for s in data:
-        if s.startswith('/'):
-            if re.fullmatch(s.split('/')[1], stage):
-                return data[s]
-    raise ValueError('No match for stage "{}"'.format(stage))
+    return run._get_stage_data(stage, data)
 
 
 def _get_kms_key(stage):

--- a/fleece/cli/run/run.py
+++ b/fleece/cli/run/run.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import os
+import re
 import subprocess
 import sys
 
@@ -55,6 +56,10 @@ def parse_args(args):
     parser.add_argument('--environment', '-e', type=str,
                         help=('Environment alias to AWS account defined in '
                               'config file. Cannot be used with `--account`'))
+    parser.add_argument('--stage', '-s', type=str,
+                        help=('Stage name defined in config file which links '
+                              'to an environment. Cannot be used with '
+                              '`--account`'))
     parser.add_argument('--role', '-r', type=str,
                         help=('Role name to assume after obtaining credentials'
                               ' from FAWS API'))
@@ -88,8 +93,29 @@ def assume_role(credentials, account, role):
     }
 
 
-def get_account(config, environment):
+def _get_stage_data(stage, data):
+    if stage in data:
+        return data[stage]
+    for s in data:
+        if s.startswith('/'):
+            if re.fullmatch(s.split('/')[1], stage):
+                return data[s]
+    raise ValueError('No match for stage "{}"'.format(stage))
+
+
+def get_environment(config, stage):
+    """Find default environment name in stage."""
+    stage_data = _get_stage_data(stage, config.get('stages', {}))
+    try:
+        return stage_data['environment']
+    except IndexError:
+        raise ValueError('No environment defined for stage "{}"'.format(stage))
+
+
+def get_account(config, environment, stage=None):
     """Find environment name in config object and return AWS account."""
+    if environment is None and stage:
+        environment = get_environment(config, stage)
     account = None
     for env in config.get('environments', []):
         if env.get('name') == environment:
@@ -160,7 +186,7 @@ def get_rackspace_token(username, apikey):
 
 def validate_args(args):
     """Validate command-line arguments."""
-    if not any([args.environment, args.account]):
+    if not any([args.environment, args.stage, args.account]):
         sys.exit(NO_ACCT_OR_ENV_ERROR)
     if args.environment and args.account:
         sys.exit(ENV_AND_ACCT_ERROR)
@@ -171,10 +197,10 @@ def validate_args(args):
 def run(args):
     role = args.role
 
-    if args.environment:
+    if args.environment or args.stage:
         config = get_config(args.config)
         account, role, cfg_username, cfg_apikey = get_account(
-            config, args.environment)
+            config, args.environment, args.stage)
     else:
         cfg_username, cfg_apikey = None, None
         account = args.account

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -235,6 +235,52 @@ class TestCLIRun(unittest.TestCase):
         self.assertEqual(username, 'foo')
         self.assertEqual(apikey, 'bar')
 
+    def test_get_account_with_stage_creds(self):
+        os.environ['MY_USERNAME'] = 'foo'
+        os.environ['MY_APIKEY'] = 'bar'
+        config = yaml.load(
+            'stages:\n'
+            '  sandwhich:\n'
+            '    environment: {env_name}\n'
+            'environments:\n'
+            '  - name: {env_name}\n'
+            '    account: "{account}"\n'
+            '    rs_username_var: MY_USERNAME\n'
+            '    rs_apikey_var: MY_APIKEY'.format(
+                env_name=self.environment, account=self.account))
+        account, role, username, apikey = run.get_account(config,
+                                                          None,
+                                                          'sandwhich')
+        del os.environ['MY_USERNAME']
+        del os.environ['MY_APIKEY']
+        self.assertEqual(account, self.account)
+        self.assertIsNone(role)
+        self.assertEqual(username, 'foo')
+        self.assertEqual(apikey, 'bar')
+
+    def test_get_account_with_stage_creds_2(self):
+        os.environ['MY_USERNAME'] = 'foo'
+        os.environ['MY_APIKEY'] = 'bar'
+        config = yaml.load(
+            'stages:\n'
+            '  /.*/:\n'
+            '    environment: {env_name}\n'
+            'environments:\n'
+            '  - name: {env_name}\n'
+            '    account: "{account}"\n'
+            '    rs_username_var: MY_USERNAME\n'
+            '    rs_apikey_var: MY_APIKEY'.format(
+                env_name=self.environment, account=self.account))
+        account, role, username, apikey = run.get_account(config,
+                                                          None,
+                                                          'made-up-nonsense')
+        del os.environ['MY_USERNAME']
+        del os.environ['MY_APIKEY']
+        self.assertEqual(account, self.account)
+        self.assertIsNone(role)
+        self.assertEqual(username, 'foo')
+        self.assertEqual(apikey, 'bar')
+
     def test_environment_not_found(self):
         with self.assertRaises(SystemExit) as exc:
             run.get_account({}, self.environment)


### PR DESCRIPTION
The config format defines "stages" which can have environments. This
allows the stages option to be specified in `fleece run` instead of an
environment. That way in scripts the same single argument (stage) can
be used for `fleece config` and `fleece run`.