### PR TITLE
Do not generate different zip / sha by default

### DIFF
--- a/fleece/cli/build/docker_build_lambda.sh
+++ b/fleece/cli/build/docker_build_lambda.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -e
+readonly inject_build_info="${1}"
+
 if [[ ! -f /build_cache/${DEPENDENCIES_SHA}.zip ]] || [[ "$REBUILD_DEPENDENCIES" == "1" ]]; then
     echo "rebuilding dependencies"
     rm -rf /build_cache/*
     mkdir /tmp/build
     /usr/bin/pip-${python_version:6:1}.${python_version:7:1} install -r /requirements/requirements.txt -t /tmp/build
     cd /tmp/build
-    zip -r /build_cache/${DEPENDENCIES_SHA}.zip .
+    zip -X -r /build_cache/${DEPENDENCIES_SHA}.zip .
 else
     echo "using cached dependencies; no rebuild"
 fi
@@ -15,7 +17,10 @@ cp /build_cache/${DEPENDENCIES_SHA}.zip /dist/lambda_function.zip
 if [[ "$EXCLUDE_PATTERNS" != "" ]]; then
     EXCLUDE="-x $EXCLUDE_PATTERNS"
 fi
-eval zip -r /dist/lambda_function.zip $EXCLUDE -- .
-cd /tmp
-echo "{\"VERSION_HASH\": \"${VERSION_HASH}\", \"BUILD_TIME\": \"${BUILD_TIME}\"}" > config.json
-zip -r /dist/lambda_function.zip config.json
+eval zip -X -r /dist/lambda_function.zip $EXCLUDE -- .
+
+if [[ -n "${inject_build_info}" ]]; then
+    cd /tmp
+    echo "{\"VERSION_HASH\": \"${VERSION_HASH}\", \"BUILD_TIME\": \"${BUILD_TIME}\"}" > config.json
+    zip -X -r /dist/lambda_function.zip config.json
+fi

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -97,6 +97,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             rebuild=False,
             exclude=None,
             dist_dir=self.rel_path('dist'),
+            inject_build_info=False,
         )
 
         # It creates a few directories...
@@ -113,7 +114,8 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
         self.make_file('Pipfile.lock', '')
 
         args = build.parse_args([
-            self.tmpdir
+            self.tmpdir,
+            '--inject-build-info'
         ])
         build.build(args)
 
@@ -128,6 +130,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             rebuild=False,
             exclude=None,
             dist_dir=self.rel_path('dist'),
+            inject_build_info=True,
         )
 
         # It creates a few directories...
@@ -162,6 +165,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             rebuild=False,
             exclude=['foo', 'bar'],
             dist_dir=self.rel_path('crazy-dist'),
+            inject_build_info=False,
         )
 
         # Make sure it creates the path.
@@ -189,6 +193,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             rebuild=False,
             exclude=None,
             dist_dir=self.rel_path('dist'),
+            inject_build_info=False,
         )
 
     @mock.patch('sys.stdout', new_callable=StringIO)
@@ -251,6 +256,7 @@ class TestBuildDispatchesToCorrectFunction(unittest.TestCase):
             rebuild=False,
             exclude=None,
             dist_dir=self.rel_path('dist'),
+            inject_build_info=False,
         )
 
 
@@ -289,7 +295,8 @@ class TestBuildWithPipenv(unittest.TestCase):
             'dependencies': ['deps'],
             'rebuild': True,
             'exclude': None,
-            'dist_dir': 'dist_dir'
+            'dist_dir': 'dist_dir',
+            'inject_build_info': False,
         }
 
         build_state = {}


### PR DESCRIPTION
This commit fixes issue 63 reported by Gifflen using methods he
described.

First, the build command always injects metadata into the zip
file. This changes the docker_build_lambda.sh script to add `-X` to
every invocation of the zip command, avoiding this.

Second, build always creates a file called config.json, containing the
version hash and build time. Now this no longer happens unless the user
passes `--inject-build-info` when calling the `fleece build` command.

With these two changes, each run of fleece build produces a zip file
whose SHA is based only by the source files given to it, and deployment
tools won't bother redeploying lambdas unless the code they contain
actually changes.