### PR TITLE
feat(xray): Force trace sampling of environment variable set

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ with requests.Session() as session:
 
 This project also bridges the gap of missing Python support in the [AWS X-Ray](https://aws.amazon.com/xray/) [Lambda integration](http://docs.aws.amazon.com/xray/latest/devguide/xray-services-lambda.html).
 
+**Update:** There's now an [official AWS X-Ray SDK for Python](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-python.html), so you might want to use that, but this implementation is still fully functional.
+
 ### Prerequisites
 
  1. Make sure you add the following permissions to the Lambda execution role of your function: `xray:PutTraceSegments` and `xray:PutTelemetryRecords`.
@@ -149,6 +151,8 @@ def get_user():
 ```
 
 **Note:** the monkey-patched tracing will also work with the wrappers described above.
+
+As of August 2018 we have experienced a strange behavior with Lambda & X-Ray where no invocations were marked for sampling, so there's now a way to force all traces to be recorded by setting the `FLEECE_XRAY_FORCE_SAMPLE` environment variable to any value.
 
 ## Connexion integration
 

--- a/tests/test_xray.py
+++ b/tests/test_xray.py
@@ -50,6 +50,42 @@ class GetTraceIDTestCase(unittest.TestCase):
         self.assertFalse(trace_id.sampled)
 
 
+class GetSampledTestCase(unittest.TestCase):
+    FORCE_ENV_VARIABLE = 'FLEECE_XRAY_FORCE_SAMPLE'
+    TRACE_ID_ENV_VARIABLE = '_X_AMZN_TRACE_ID'
+
+    def test_no_environment_variables_set(self):
+        self.assertFalse(xray.get_sampled())
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            TRACE_ID_ENV_VARIABLE: 'Root=1-5901e3bc-8da3814a5f3ccbc864b66ecc;Sampled=0'  # noqa
+        }
+    )
+    def test_trace_not_sampled(self):
+        self.assertFalse(xray.get_sampled())
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            TRACE_ID_ENV_VARIABLE: 'Root=1-5901e3bc-8da3814a5f3ccbc864b66ecc;Sampled=1'  # noqa
+        }
+    )
+    def test_trace_sampled(self):
+        self.assertTrue(xray.get_sampled())
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            FORCE_ENV_VARIABLE: '1',
+            TRACE_ID_ENV_VARIABLE: 'Root=1-5901e3bc-8da3814a5f3ccbc864b66ecc;Sampled=0',  # noqa
+        }
+    )
+    def test_trace_force_sampled(self):
+        self.assertTrue(xray.get_sampled())
+
+
 class GetXRayDaemonTestCase(unittest.TestCase):
     ENV_VARIABLE = 'AWS_XRAY_DAEMON_ADDRESS'
 


### PR DESCRIPTION
We have experienced a strange behavior with Lambda & X-Ray where no invocations were marked for sampling, so there's now a way to force all traces to be recorded by setting the `FLEECE_XRAY_FORCE_SAMPLE` environment variable to any value.