### PR TITLE
Bump Flask version to 0.12.4 due to CVE-2018-1000656

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 boto3>=1.0.0
 connexion==1.1.9
-Flask==0.12.2
+Flask==0.12.4
 requests==2.9.1
 ruamel.yaml==0.15.34
 six==1.11.0


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-1000656.

0.12.4 is not the latest version of Flask at the present time, but it is
a patched version that is pre 1.0. I felt that it would be too much of a
change to push to 1.0, since the jump from 0.12.4 to 1.0 includes a
_lot_ of changes:

http://flask.pocoo.org/docs/1.0/changelog/#version-1-0