### PR TITLE
Update docker-py to v3.5.0

### DIFF
--- a/fleece/cli/build/build.py
+++ b/fleece/cli/build/build.py
@@ -262,7 +262,7 @@ def _build(service_name, python_version, src_dir, requirements_path,
     except:
         raise RuntimeError("Docker not found.")
 
-    image = docker_api.images.build(
+    image, _logs = docker_api.images.build(
         path=build_dir, tag=service_name,
         buildargs={'python_version': python_version,
                    'deps': ' '.join(dependencies)})

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRAS_REQUIRE = {
         'Werkzeug==0.12.2',
     ],
     'cli': [
-        'docker==2.5.1',
+        'docker==3.5.0',
         'PyYAML>=3.12',
         'ruamel.yaml>=0.15.34',
         'six>=1.11.0'


### PR DESCRIPTION
My motivation for this PR was seeing a bunch of [docker-related errors](https://gist.github.com/jmillxyz/e59defb9fdbc40ddec71cfe2284159c3) during `fleece build`. To be honest I'm not sure if they'll fix everything, but I saw that more recent versions of docker-py have official Docker SDK support for Py36.

Per docker-py's [v3.0.0 release notes](https://github.com/docker/docker-py/releases/tag/3.0.0), the return value of `DockerClient.images.build()` has changed to a tuple, with the second value being a generator of the build logs.

Since it's unused I named it `_logs` but anything will do!
