### PR TITLE
Upgrade `requests` from 2.9.1 to 2.20.0

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,7 +1,7 @@
 boto3>=1.0.0
 connexion==1.1.9
 Flask==0.12.4
-requests==2.9.1
+requests==2.20.0
 ruamel.yaml==0.15.34
 six==1.11.0
 structlog==16.0.0


### PR DESCRIPTION
Addresses a moderate security vulnerability reported to us by github.com
and documented at https://nvd.nist.gov/vuln/detail/CVE-2018-18074